### PR TITLE
Add live coding support

### DIFF
--- a/apps/MachinekitClient/MachinekitClient.LiveCoding/LiveCoding.qml
+++ b/apps/MachinekitClient/MachinekitClient.LiveCoding/LiveCoding.qml
@@ -1,0 +1,122 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 Alexander Rössler
+** License: LGPL version 2.1
+**
+** This file is part of QtQuickVcp.
+**
+** All rights reserved. This program and the accompanying materials
+** are made available under the terms of the GNU Lesser General Public License
+** (LGPL) version 2.1 which accompanies this distribution, and is available at
+** http://www.gnu.org/licenses/lgpl-2.1.html
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+** Contributors:
+** Alexander Rössler <alexander AT roessler DOT systems>
+**
+****************************************************************************/
+
+import QtQuick 2.0
+import QtQuick.Controls 1.1
+import QtQuick.Window 2.0
+import QtQuick.Layouts 1.3
+import Qt.labs.platform 1.0
+import Machinekit.Application 1.0
+
+Item {
+    property string title: qsTr("QtQuickVcp Live Coding") + (loader.item ? " - " + loader.item.title : "")
+    property var statusBar: null
+    property var menuBar: null
+    property var toolBar: null
+    property var services: (((loader.item !== null) && (loader.item.services !== undefined)) ? loader.item.services : [])
+
+    /* Disconnects this page */
+    signal disconnect()
+
+    id: root
+
+    QtObject {
+        id: d
+
+        function reload() {
+            loader.source = "";
+            ApplicationHelpers.clearQmlComponentCache();
+            loader.source = fileDialog.file;
+        }
+    }
+
+    Label {
+        id: dummyText
+        visible: false
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        RowLayout {
+            Button {
+                text: qsTr("Open")
+                onClicked: fileDialog.open()
+            }
+
+            Button {
+                text: qsTr("Reload")
+                onClicked: d.reload()
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            Button {
+                text: qsTr("Disconnect")
+                onClicked: root.disconnect()
+            }
+        }
+
+        Loader {
+            id: loader
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            onStatusChanged: {
+                if (status !== Loader.Error) {
+                    return;
+                }
+
+                var msg = loader.sourceComponent.errorString();
+                errorLabel.text = qsTr("QML Error: Loading QML file failed:\n") + msg;
+            }
+
+            Label {
+                id: errorLabel
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                font.pointSize: dummyText.font.pointSize * 1.1
+                visible: loader.status === Loader.Error
+            }
+        }
+    }
+
+    FileDialog {
+        property bool selected: false
+        id: fileDialog
+        folder: StandardPaths.writableLocation(StandardPaths.HomeLocation)
+        onFileChanged: d.reload()
+        onAccepted: selected = true
+    }
+
+    FileWatcher {
+        id: fileWatcher
+        fileUrl: fileDialog.selected ? fileDialog.folder : ""
+        recursive: true
+        onFileChanged: d.reload()
+    }
+}

--- a/apps/MachinekitClient/MachinekitClient.LiveCoding/description.ini
+++ b/apps/MachinekitClient/MachinekitClient.LiveCoding/description.ini
@@ -1,0 +1,4 @@
+[Default]
+name=Live Coding
+description=Live coding environment for QtQuickVcp.
+type=QT5_QML

--- a/apps/MachinekitClient/main.qml
+++ b/apps/MachinekitClient/main.qml
@@ -64,6 +64,10 @@ Item {
         ApplicationDescription {
             sourceDir: "./MachinekitClient.ServiceDisplay"
         }
+
+        ApplicationDescription {
+            sourceDir: "./MachinekitClient.LiveCoding"
+        }
     }
 
     Component.onCompleted: {

--- a/apps/MachinekitClient/qml.qrc
+++ b/apps/MachinekitClient/qml.qrc
@@ -10,5 +10,7 @@
         <file>MachinekitClient.ServiceDisplay/translations/servicedisplay_de.qm</file>
         <file>MachinekitClient.ServiceDisplay/translations/servicedisplay_en.qm</file>
         <file>MachinekitClient.ServiceDisplay/translations/servicedisplay_ru.qm</file>
+        <file>MachinekitClient.LiveCoding/description.ini</file>
+        <file>MachinekitClient.LiveCoding/LiveCoding.qml</file>
     </qresource>
 </RCC>

--- a/src/application/ApplicationCore.qml
+++ b/src/application/ApplicationCore.qml
@@ -210,6 +210,7 @@ Item {
         id: fileWatcher
         fileUrl: enabled ? applicationFile.localFilePath : ""
         enabled: applicationFile.transferState === ApplicationFile.NoTransfer
+        recursive: false
         onFileChanged: _localFileChanged()
     }
 

--- a/src/application/applicationhelpers.cpp
+++ b/src/application/applicationhelpers.cpp
@@ -3,8 +3,9 @@
 
 namespace qtquickvcp {
 
-ApplicationHelpers::ApplicationHelpers(QObject *parent)
+ApplicationHelpers::ApplicationHelpers(QQmlEngine *engine, QObject *parent)
     : QObject(parent)
+    , m_engine(engine)
 {
 
 }
@@ -12,6 +13,11 @@ ApplicationHelpers::ApplicationHelpers(QObject *parent)
 bool ApplicationHelpers::openUrlWithDefaultApplication(const QUrl &url) const
 {
     return QDesktopServices::openUrl(url);
+}
+
+void ApplicationHelpers::clearQmlComponentCache() const
+{
+    m_engine->clearComponentCache();
 }
 
 } // namespace qtquickvcp

--- a/src/application/applicationhelpers.h
+++ b/src/application/applicationhelpers.h
@@ -10,14 +10,14 @@ class ApplicationHelpers : public QObject
 {
     Q_OBJECT
 public:
-    explicit ApplicationHelpers(QObject *parent = nullptr);
+    explicit ApplicationHelpers(QQmlEngine *engine, QObject *parent = nullptr);
 
     static QObject *qmlSingletonProvider(QQmlEngine *engine, QJSEngine *scriptEngine)
     {
         Q_UNUSED(engine)
         Q_UNUSED(scriptEngine)
 
-        return  new ApplicationHelpers();
+        return  new ApplicationHelpers(engine);
     }
 
     /**
@@ -25,6 +25,14 @@ public:
      * E.g. a text file will be opened by the default text editor.
      */
     Q_INVOKABLE bool openUrlWithDefaultApplication(const QUrl &url) const;
+
+    /**
+     * Clear QML component cache of the main QQmlEngine.
+     */
+    Q_INVOKABLE void clearQmlComponentCache() const;
+
+private:
+    QQmlEngine *m_engine;
 
 }; // class ApplicationHelpers
 } // namespace qtquickvcp

--- a/src/application/fileio.cpp
+++ b/src/application/fileio.cpp
@@ -1,3 +1,25 @@
+/****************************************************************************
+**
+** Copyright (C) 2017 Alexander Rössler
+** License: LGPL version 2.1
+**
+** This file is part of QtQuickVcp.
+**
+** All rights reserved. This program and the accompanying materials
+** are made available under the terms of the GNU Lesser General Public License
+** (LGPL) version 2.1 which accompanies this distribution, and is available at
+** http://www.gnu.org/licenses/lgpl-2.1.html
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+** Contributors:
+** Alexander Rössler <alexander AT roessler DOT systems>
+**
+****************************************************************************/
+
 #include "fileio.h"
 #include <QFile>
 #include <QTextStream>
@@ -62,7 +84,7 @@ void FileIO::write()
 
 /* Read text from file */
 void FileIO::read()
-{    
+{
     if (!m_fileUrl.isValid() || !m_fileUrl.isLocalFile())
     {
         emit error(tr("File url is not valid"));

--- a/src/application/filewatcher.h
+++ b/src/application/filewatcher.h
@@ -12,30 +12,37 @@ class FileWatcher : public QObject
     Q_OBJECT
     Q_PROPERTY(QUrl fileUrl READ fileUrl WRITE setFileUrl NOTIFY fileUrlChanged)
     Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+    Q_PROPERTY(bool recursive READ recursive WRITE setRecursive NOTIFY recursiveChanged)
 
 public:
     explicit FileWatcher(QObject *parent = nullptr);
 
     QUrl fileUrl() const;
     bool enabled() const;
+    bool recursive() const;
 
 signals:
     void fileChanged();
     void fileUrlChanged(const QUrl &fileUrl);
     void enabledChanged(bool enabled);
 
+    void recursiveChanged(bool recursive);
+
 public slots:
     void setFileUrl(const QUrl &fileUrl);
     void setEnabled(bool enabled);
+    void setRecursive(bool recursive);
 
 private:
     QUrl m_fileUrl;
     bool m_enabled;
+    bool m_recursive;
     QFileSystemWatcher m_fileSystemWatcher;
 
 private slots:
     void updateWatchedFile();
     void onWatchedFileChanged();
+    void onWatchedDirectoryChanged(const QString &path);
 
 }; // class FileWatcher
 } // namespace qtquickvcp

--- a/src/applicationcontrols/translations/machinekitapplicationcontrols_de.ts
+++ b/src/applicationcontrols/translations/machinekitapplicationcontrols_de.ts
@@ -9,7 +9,7 @@
     </message>
     <message>
         <source>Loading QML file failed</source>
-        <translation>Laden der QML Datei fehlgeschlagen
+        <translation type="vanished">Laden der QML Datei fehlgeschlagen
 </translation>
     </message>
 </context>

--- a/src/applicationcontrols/translations/machinekitapplicationcontrols_en.ts
+++ b/src/applicationcontrols/translations/machinekitapplicationcontrols_en.ts
@@ -7,10 +7,6 @@
         <source>QML Error:</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Loading QML file failed</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>ApplicationFileDialog</name>

--- a/src/applicationcontrols/translations/machinekitapplicationcontrols_ru.ts
+++ b/src/applicationcontrols/translations/machinekitapplicationcontrols_ru.ts
@@ -7,10 +7,6 @@
         <source>QML Error:</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Loading QML file failed</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>ApplicationFileDialog</name>

--- a/tests/servicediscoverytests/qjdns_stub.cpp
+++ b/tests/servicediscoverytests/qjdns_stub.cpp
@@ -13,7 +13,7 @@ QJDns::~QJDns()
 {
 }
 
-bool QJDns::init(Mode mode, const QHostAddress &address)
+bool QJDns::init(Mode, const QHostAddress &)
 {
     return true;
 }
@@ -28,16 +28,16 @@ QJDns::SystemInfo QJDns::systemInfo()
     return SystemInfo();
 }
 
-void QJDns::setNameServers(const QList<NameServer> &list)
+void QJDns::setNameServers(const QList<NameServer> &)
 {
 
 }
 
-int QJDns::queryStart(const QByteArray &name, int type)
+int QJDns::queryStart(const QByteArray &, int)
 {
     return 0;
 }
 
-void QJDns::queryCancel(int id)
+void QJDns::queryCancel(int)
 {
 }


### PR DESCRIPTION
Installing Qt SDK seems to be a big pain for non-developers. However, to write a QtQuickVcp application one does not even need a Qt SDK installed.

This PR unleashes the full power of QML by adding a Live Coding application to the MachinekitClient.

Users of QtQuickVcp can now create new applications or adapt existing ones just by editing them with their favorite text editor.